### PR TITLE
Corrected the file needed to require in Capfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 
 Add this line to your `Capfile`
 
-    require 'capistrano/nginx_unicorn'
+    require 'capistrano3/nginx_unicorn'
 
 Note, that following capistrano variables should be defined:
 


### PR DESCRIPTION
Hi @jesson,

I updated README.md. I noticed that you should require 'capistrano3/nginx_unicorn' instead of 'capistrano/nginx_unicorn'

Signed-off-by: Paolo Ibarra jpibarra1130@gmail.com
