### PR TITLE
fix nginx_upload_local_certificate

### DIFF
--- a/lib/capistrano3/tasks/nginx_unicorn.rake
+++ b/lib/capistrano3/tasks/nginx_unicorn.rake
@@ -30,7 +30,7 @@ namespace :nginx do
       execute "sudo ln -fs #{fetch(:nginx_config_path)}/sites-available/#{fetch(:application)}.conf #{fetch(:nginx_config_path)}/sites-enabled/#{fetch(:application)}.conf"
 
       if fetch(:nginx_use_ssl)
-        if nginx_upload_local_certificate
+        if fetch(:nginx_upload_local_certificate)
           put File.read(nginx_ssl_certificate_local_path), "/tmp/#{fetch(:nginx_ssl_certificate)}"
           put File.read(nginx_ssl_certificate_key_local_path), "/tmp/#{fetch(:nginx_ssl_certificate_key)}"
 
@@ -106,4 +106,3 @@ def template(template_name, target)
   end
   upload! StringIO.new(ERB.new(File.read(config_file)).result(binding)), target
 end
-


### PR DESCRIPTION
this was causing my deploys to break with a NoMethodError since nginx_upload_local_certificate is a variable instead of a method, this fixes it.
